### PR TITLE
update: Terrain初期化と設定変更

### DIFF
--- a/GameProject/Terrain/Terrain.cpp
+++ b/GameProject/Terrain/Terrain.cpp
@@ -9,6 +9,7 @@ void Terrain::Initialize()
     for (int i = 0; i < kNumBlocks; ++i)
     {
         auto block = std::make_unique<Block>();
+        block->Initialize();
         block->SetPosition(this->ToVector3(i));
         blocks_.emplace_back(std::move(block));
     }

--- a/GameProject/imgui.ini
+++ b/GameProject/imgui.ini
@@ -84,9 +84,9 @@ Size=171,55
 Collapsed=0
 
 [Window][CollisionManager Debug]
-Pos=831,68
+Pos=779,529
 Size=420,343
-Collapsed=0
+Collapsed=1
 
 [Docking][Data]
 DockSpace ID=0xF852211D Window=0xA87D555D Pos=0,0 Size=1280,720 CentralNode=1

--- a/GameProject/resources/Model/Box.mtl
+++ b/GameProject/resources/Model/Box.mtl
@@ -10,4 +10,4 @@ Ke 0.000000 0.000000 0.000000
 Ni 1.450000
 d 1.000000
 illum 2
-map_Kd white1x1.png
+map_Kd white.png


### PR DESCRIPTION
* `Terrain.cpp`
  - `Terrain::Initialize`関数に`block->Initialize();`を追加し、ブロックの初期化を改善しました。

* `imgui.ini`
  - ウィンドウの`Collapsed`設定を`0`から`1`に変更し、ウィンドウが折りたたまれるようにしました。

* `Box.mtl`
  - `map_Kd`のテクスチャファイルを`white1x1.png`から`white.png`に変更しました。

バイナリファイルやJSONの変更はありません。