### PR TITLE
change: Block::Color を Block::Colors に変更

### DIFF
--- a/GameProject/Object/Player/Player.cpp
+++ b/GameProject/Object/Player/Player.cpp
@@ -98,16 +98,16 @@ void Player::Move(float speedMultiplier)
 
 void Player::Action() {
     //床の色を判別する
-    Block::Color blockColor = Block::Color::White;
+    Block::Colors blockColor = Block::Colors::White;
 
     if (terrain_) {
         blockColor = terrain_->GetBlockColorAt(transform_.translate);
     }
 
     if (inputHandler_) Move();
-    if (blockColor == Block::Color::Red && inputHandler_->IsAttacking()) Attack();
-    if (blockColor == Block::Color::Blue && inputHandler_->IsDashing()) Dash();
-    if (blockColor == Block::Color::Yellow && inputHandler_->IsJumping()) Jump();
+    if (blockColor == Block::Colors::Red && inputHandler_->IsAttacking()) Attack();
+    if (blockColor == Block::Colors::Blue && inputHandler_->IsDashing()) Dash();
+    if (blockColor == Block::Colors::Yellow && inputHandler_->IsJumping()) Jump();
 
     Apply();
 }
@@ -151,7 +151,7 @@ void Player::DrawImGui()
     int currentColor = static_cast<int>(color_);
     
     if (ImGui::Combo("Color", &currentColor, colorNames, IM_ARRAYSIZE(colorNames))) {
-        color_ = static_cast<Block::Color>(currentColor);
+        color_ = static_cast<Block::Colors>(currentColor);
     }
     
     if (ImGui::Button("SetColor")){

--- a/GameProject/Object/Player/Player.h
+++ b/GameProject/Object/Player/Player.h
@@ -35,7 +35,7 @@ class Player
     bool isAttackHit_ = false;
     float attackMoveSpeed_ = 2.0f;
 
-    Block::Color color_;
+    Block::Colors color_;
 public: // メンバ関数
     Player();
     ~Player();

--- a/GameProject/imgui.ini
+++ b/GameProject/imgui.ini
@@ -113,10 +113,10 @@ Collapsed=0
 DockId=0x0000000B,0
 
 [Window][Player]
-Pos=0,431
-Size=318,113
+Pos=444,45
+Size=1156,855
 Collapsed=0
-DockId=0x0000000C,0
+DockId=0x0000000C,1
 
 [Docking][Data]
 DockSpace         ID=0xF852211D Window=0xA87D555D Pos=0,0 Size=1600,900 Split=Y Selected=0x4E65C02E


### PR DESCRIPTION
- `Player::Action` メソッド内でのブロックの色の判別を `Block::Colors` に対応させました。
- `Player::DrawImGui` メソッドでも色の設定に使用される型を変更しました。
- `Player` クラスのメンバ変数 `color_` を `Block::Colors` に変更し、一貫性を保ちました。
- `imgui.ini` ファイルで `Player` ウィンドウの位置とサイズを更新しました。