### PR TITLE
feat: BlockとTerrainにImGui機能を追加

### DIFF
--- a/GameProject/Terrain/Block/Block.cpp
+++ b/GameProject/Terrain/Block/Block.cpp
@@ -1,6 +1,7 @@
 #include "./Block.h"
 #include <Features/Color/Color.h>
 #include <unordered_map>
+#include <imgui.h>
 
 const float Block::kScale = 10.0f;
 
@@ -35,6 +36,27 @@ void Block::Update()
 void Block::Draw()
 {
 
+}
+
+void Block::ImGui()
+{
+    #ifdef _DEBUG
+
+    if (modelInstance_)
+    {
+        const char* colorNames[] = { "White", "Gray", "Blue", "Green", "Red", "Yellow", "Purple", "Orange" };
+        int currentColor = static_cast<int>(color_);
+        if (ImGui::Combo("Color", &currentColor, colorNames, IM_ARRAYSIZE(colorNames)))
+        {
+            this->SetColor(static_cast<Colors>(currentColor));
+        }
+
+        ImGui::SeparatorText("Detail");
+        const auto& position = modelInstance_->GetTransform().translate;
+        ImGui::Text("Position: (%.2f, %.2f, %.2f)", position.x, position.y, position.z);
+    }
+
+    #endif // _DEBUG
 }
 
 void Block::SetColor(Colors color)

--- a/GameProject/Terrain/Block/Block.h
+++ b/GameProject/Terrain/Block/Block.h
@@ -33,6 +33,7 @@ public:
     void Initialize(std::unique_ptr<ModelInstance> modelInstance);
     void Update();
     void Draw();
+    void ImGui();
 
     Colors GetColor() const { return color_; }
     void SetColor(Colors color);

--- a/GameProject/Terrain/Terrain.cpp
+++ b/GameProject/Terrain/Terrain.cpp
@@ -1,12 +1,12 @@
 #include "./Terrain.h"
 #include <stdexcept>
+#include <imgui.h>
+#include <Draw2D.h>
+#include <Features/Color/Color.h>
 
 
 void Terrain::Initialize()
 {
-    // (x * y * z) を意識
-    blocks_.reserve(kNumBlocks);
-
     const float blockScale = Block::kScale;
 
     // Initialize InstancedObject3d
@@ -15,29 +15,67 @@ void Terrain::Initialize()
 
     // Initialize terrain blocks
     Transform tf = {};
-    for (int i = 0; i < kNumBlocks; ++i)
-    {
-        tf.translate = this->ToWorldVector3(i);
-        tf.translate.y -= blockScale * .5f;
 
-        auto block = std::make_unique<Block>();
-        block->Initialize(instancedObjectBlock_->CreateInstance(tf));
-        blocks_.emplace_back(std::move(block));
+    for (int x = 0; x < kSize; ++x)
+    {
+        for (int y = 0; y < kHeight; ++y)
+        {
+            for (int z = 0; z < kSize; ++z)
+            {
+                bool isUpper = (x < kWidth && z < kWidth) || (x >= kWidth && z >= kWidth);
+                if (isUpper)
+                {
+                    tf.translate = Vector3(static_cast<float>(x), static_cast<float>(-y), static_cast<float>(z));
+                    tf.translate *= blockScale;
+
+                    auto block = std::make_unique<Block>();
+                    block->Initialize(instancedObjectBlock_->CreateInstance(tf));
+                    blocks_[x][y][z] = std::move(block);
+                }
+                else if (y == 1)
+                {
+                    tf.translate = Vector3(static_cast<float>(x), static_cast<float>(-y), static_cast<float>(z));
+                    tf.translate *= blockScale;
+
+                    auto block = std::make_unique<Block>();
+                    block->Initialize(instancedObjectBlock_->CreateInstance(tf));
+                    blocks_[x][y][z] = std::move(block);
+                }
+            }
+        }
     }
+
+    //for (int i = 0; i < kNumBlocks; ++i)
+    //{
+    //    tf.translate = this->ToWorldVector3(i);
+    //    tf.translate.y -= blockScale * .5f;
+
+    //    auto block = std::make_unique<Block>();
+    //    block->Initialize(instancedObjectBlock_->CreateInstance(tf));
+    //    blocks_[i] = std::move(block);
+    //}
 }
 
 void Terrain::Finalize()
 {
-    blocks_.clear();
 }
 
 void Terrain::Update()
 {
     instancedObjectBlock_->Update();
 
-    for (auto& block : blocks_)
+    for (int x = 0; x < kSize; ++x)
     {
-        block->Update();
+        for (int y = 0; y < kHeight; ++y)
+        {
+            for (int z = 0; z < kSize; ++z)
+            {
+                if (blocks_[x][y][z])
+                {
+                    blocks_[x][y][z]->Update();
+                }
+            }
+        }
     }
 }
 
@@ -45,11 +83,64 @@ void Terrain::Draw()
 {
     instancedObjectBlock_->Draw();
 
-    for (auto& block : blocks_)
+    for (int x = 0; x < kSize; ++x)
     {
-        block->Draw();
+        for (int y = 0; y < kHeight; ++y)
+        {
+            for (int z = 0; z < kSize; ++z)
+            {
+                if (blocks_[x][y][z])
+                {
+                    blocks_[x][y][z]->Draw();
+                }
+            }
+        }
     }
 }
+
+void Terrain::ImGui()
+{
+    bool isOpen = ImGui::Begin("Terrain");
+    if (isOpen)
+    {
+        ImGui::SeparatorText("Select block");
+        ImGui::Indent(15.0f);
+        int x = static_cast<int>(selectPosition_.x);
+        int y = static_cast<int>(selectPosition_.y);
+        int z = static_cast<int>(selectPosition_.z);
+        ImGui::SliderInt("X", &x, 0, kSize-1);
+        ImGui::SliderInt("Y", &y, -static_cast<int>(kHeight) + 1, 0);
+        ImGui::SliderInt("Z", &z, 0, kSize-1);
+
+        selectPosition_ = Vector3(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z));
+
+        AABB aabb = {};
+        aabb.min = selectPosition_ * Block::kScale;
+        aabb.min.x -= Block::kScale * 0.5f;
+        aabb.min.y -= Block::kScale * 0.5f;
+        aabb.min.z -= Block::kScale * 0.5f;
+
+        aabb.max = aabb.min + Vector3(Block::kScale, Block::kScale, Block::kScale);
+        Draw2D::GetInstance()->DrawAABB(aabb, Color(0x4688ecff).Vec4());
+
+        ImGui::Separator();
+        ImGui::Indent(15.0f);
+
+        auto& block = blocks_[x][-y][z];
+        if (block)
+        {
+            blocks_[x][-y][z]->ImGui();
+        }
+        else
+        {
+            ImGui::Text("This is air block");
+        }
+
+        ImGui::Unindent(15.0f);
+        ImGui::Unindent(15.0f);
+        ImGui::End();
+    }
+};
 
 Vector3 Terrain::ToLocalVector3(uint32_t index)
 {
@@ -59,20 +150,6 @@ Vector3 Terrain::ToLocalVector3(uint32_t index)
     int z = index % kSize;
 
     return Vector3(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z));
-}
-
-Vector3 Terrain::ToWorldVector3(uint32_t index)
-{
-    return ToLocalVector3(index) * Block::kScale;
-}
-
-uint32_t Terrain::ToIndex(const Vector3& position)
-{
-    auto normPosition = position / Block::kScale;
-    int x = static_cast<int>(normPosition.x);
-    int y = static_cast<int>(-normPosition.y);
-    int z = static_cast<int>(normPosition.z);
-    return y * kSize * kSize + x * kSize + z;
 }
 
 Block::Colors Terrain::GetBlockColorAt(const Vector3& position)
@@ -89,30 +166,30 @@ Block::Colors Terrain::GetBlockColorAt(const Vector3& position)
 
 Block* Terrain::GetBlockAt(const Vector3& position)
 {
-    uint32_t i = Terrain::ToIndex(position);
-
     // 範囲外の場合はvector側でExeptionされる
-    return blocks_.at(i).get();
+    auto normPosition = position / Block::kScale;
+    int x = static_cast<int>(normPosition.x);
+    int y = static_cast<int>(-normPosition.y);
+    int z = static_cast<int>(normPosition.z);
+    return blocks_[x][y][z].get();
 }
 
 bool Terrain::HasBlockAt(const Vector3& position)
 {
-    uint32_t i = Terrain::ToIndex(position);
-    return i < kNumBlocks;
+    try
+    {
+        Block* block = this->GetBlockAt(position);
+        return block != nullptr;
+    }
+    catch (const std::out_of_range&)
+    {
+        return false;
+    }
 }
 
 void Terrain::SetBlockColorAt(const Vector3& position, Block::Colors color)
 {
     Block* block = this->GetBlockAt(position);
-    if (block)
-    {
-        block->SetColor(color);
-    }
-}
-
-void Terrain::SetBlockColorAt(uint32_t index, Block::Colors color)
-{
-    Block* block = blocks_.at(index).get();
     if (block)
     {
         block->SetColor(color);
@@ -126,22 +203,17 @@ float Terrain::GetMaxYAt(float x, float z)
 
     if (ix < 0 || ix >= static_cast<int>(kSize) || iz < 0 || iz >= static_cast<int>(kSize))
     {
-        throw std::out_of_range("XZ position is out of terrain bounds");
+        throw std::out_of_range("Terrain::GetMaxYAt: x or z is out of range");
     }
 
     for (int y = 0; y < static_cast<int>(kHeight); ++y)
     {
-        Vector3 pos(static_cast<float>(ix), static_cast<float>(-y), static_cast<float>(iz));
-        if (this->HasBlockAt(pos))
+        if (blocks_[ix][y][iz])
         {
-            Block* block = this->GetBlockAt(pos);
-            if (block)
-            {
-                return (static_cast<float>(-y) + 0.5f) * Block::kScale;
-            }
+            return -static_cast<float>(y) * Block::kScale;
         }
     }
 
-    // ブロックが見つからなかった場合
+    // ブロックが見つからなかった場合、地面の高さを返す
     return 0.0f;
 }

--- a/GameProject/Terrain/Terrain.h
+++ b/GameProject/Terrain/Terrain.h
@@ -8,8 +8,9 @@
 class Terrain
 {
 public:
-    static const uint32_t kSize = 20;
+    static const uint32_t kWidth = 10;
     static const uint32_t kHeight = 2;
+    static const uint32_t kSize = kWidth * 2;
     static const uint32_t kNumBlocks = kSize * kHeight * kSize;
 
     Terrain() = default;
@@ -19,10 +20,9 @@ public:
     void Finalize();
     void Update();
     void Draw();
+    void ImGui();
 
     static Vector3 ToLocalVector3(uint32_t index);
-    static Vector3 ToWorldVector3(uint32_t index);
-    static uint32_t ToIndex(const Vector3& position);
 
     /// Getters
 
@@ -40,13 +40,18 @@ public:
     // 座標に対応するブロックの色を変更 (範囲外は例外)
     void SetBlockColorAt(const Vector3& position, Block::Colors color);
 
-    // インデックスに対応するブロックの色を変更 (範囲外は例外)
-    void SetBlockColorAt(uint32_t index, Block::Colors color);
-
     // XZ-座標からY座標の最大値を取得。範囲外は例外
     float GetMaxYAt(float x, float z);
 
 private:
     std::unique_ptr<InstancedObject3d> instancedObjectBlock_;
-    std::vector <std::unique_ptr<Block>> blocks_;
+
+    template <class type, int sx, int sy, int sz>
+    using Array3D = std::array<std::array<std::array<type, sz>, sy>, sx>;
+
+    Array3D<std::unique_ptr<Block>, kSize, kHeight, kSize> blocks_;
+
+    #ifdef _DEBUG
+    Vector3 selectPosition_ = { 0.0f, 0.0f, 0.0f };
+    #endif // _DEBUG
 };

--- a/GameProject/imgui.ini
+++ b/GameProject/imgui.ini
@@ -95,8 +95,8 @@ Collapsed=0
 DockId=0x00000008,0
 
 [Window][Game Viewport]
-Pos=423,45
-Size=1177,855
+Pos=444,45
+Size=1156,855
 Collapsed=0
 DockId=0x0000000C,0
 
@@ -113,10 +113,16 @@ Collapsed=0
 DockId=0x0000000B,0
 
 [Window][Player]
-Pos=444,45
-Size=1156,855
+Pos=0,45
+Size=442,499
 Collapsed=0
-DockId=0x0000000C,1
+DockId=0x00000007,2
+
+[Window][Terrain]
+Pos=0,45
+Size=442,499
+Collapsed=0
+DockId=0x00000007,3
 
 [Docking][Data]
 DockSpace         ID=0xF852211D Window=0xA87D555D Pos=0,0 Size=1600,900 Split=Y Selected=0x4E65C02E
@@ -125,7 +131,7 @@ DockSpace         ID=0xF852211D Window=0xA87D555D Pos=0,0 Size=1600,900 Split=Y 
     DockNode      ID=0x00000006 Parent=0x00000003 SizeRef=287,60 HiddenTabBar=1 Selected=0x6108FA95
   DockNode        ID=0x00000004 Parent=0xF852211D SizeRef=1280,675 Split=X
     DockNode      ID=0x00000001 Parent=0x00000004 SizeRef=442,720 Split=Y Selected=0xDE934E82
-      DockNode    ID=0x00000007 Parent=0x00000001 SizeRef=318,394 Selected=0x0698FD4C
+      DockNode    ID=0x00000007 Parent=0x00000001 SizeRef=318,394 Selected=0x28B4A56B
       DockNode    ID=0x00000008 Parent=0x00000001 SizeRef=318,279 Selected=0x39D99776
     DockNode      ID=0x00000002 Parent=0x00000004 SizeRef=1156,720 Split=X Selected=0x4E65C02E
       DockNode    ID=0x00000009 Parent=0x00000002 SizeRef=318,675 Selected=0xD52612CC

--- a/GameProject/scene/GameScene.cpp
+++ b/GameProject/scene/GameScene.cpp
@@ -219,6 +219,7 @@ void GameScene::DrawImGui()
     player_->DrawImGui();
     boss_->DrawImGui();
     followCamera_->DrawImGui();
+    terrain_->ImGui();
     ShadowRenderer::GetInstance()->DrawImGui();
     CollisionManager::GetInstance()->DrawImGui();
     #endif // DEBUG

--- a/GameProject/scene/TitleScene.cpp
+++ b/GameProject/scene/TitleScene.cpp
@@ -198,12 +198,15 @@ void TitleScene::SpritesUpdate()
 
 void TitleScene::TerrainUpdate()
 {
-    uint32_t random = std::rand() % Terrain::kNumBlocks;
-    terrain_->SetBlockColorAt(random, Block::Colors::Orange);
-    random = std::rand() % Terrain::kNumBlocks;
-    terrain_->SetBlockColorAt(random, Block::Colors::Purple);
-    random = std::rand() % Terrain::kNumBlocks;
-    terrain_->SetBlockColorAt(random, Block::Colors::Blue);
+    float x = static_cast<float>(std::rand() % Terrain::kWidth);
+    float z = static_cast<float>(std::rand() % Terrain::kWidth);
+    terrain_->SetBlockColorAt({x, 0.0f, z}, Block::Colors::Orange);
+    x = static_cast<float>(std::rand() % Terrain::kWidth);
+    z = static_cast<float>(std::rand() % Terrain::kWidth);
+    terrain_->SetBlockColorAt({x, 0.0f, z}, Block::Colors::Purple);
+    x = static_cast<float>(std::rand() % Terrain::kWidth);
+    z = static_cast<float>(std::rand() % Terrain::kWidth);
+    terrain_->SetBlockColorAt({x, 0.0f, z}, Block::Colors::Blue);
 
     terrain_->Update();
 }


### PR DESCRIPTION
- `Block`クラスにデバッグ用の`ImGui`メソッドを追加し、色選択や位置表示が可能に。
- `Terrain`クラスのブロック初期化方法を変更し、3次元配列での管理を導入。
- `Terrain`クラスに`ImGui`メソッドを追加し、選択したブロックの情報を表示。
- `Block.h`に`ImGui`メソッドの宣言を追加。
- `Terrain.h`でブロックサイズに関する定数を変更し、データ構造を3次元配列に更新。
- `GameScene`でデバッグ時に`terrain_`の`ImGui`メソッドを呼び出すように変更。
- `TitleScene`でブロックの色設定をインデックスから座標に変更。

その他、`imgui.ini`のウィンドウ位置とサイズを調整しました。