### PR TITLE
change: Initializeメソッドの引数を変更

### DIFF
--- a/GameProject/Bar3d/Bar3d.cpp
+++ b/GameProject/Bar3d/Bar3d.cpp
@@ -2,14 +2,11 @@
 #include <WinApp.h>
 #include <Mat4x4Func.h>
 
-void Bar3d::Initialize()
+void Bar3d::Initialize(const Color& colorContext, const Color& colorBG)
 {
-    auto maxColor = Color(0x000000cc);
-    auto currentColor = Color(0xd91e1e);
-
     // Initialize the background sprite
-    InitializeSprite(sprite_max_, maxColor);
-    InitializeSprite(sprite_current_, currentColor);
+    InitializeSprite(sprite_max_, colorBG);
+    InitializeSprite(sprite_current_, colorContext);
 }
 
 void Bar3d::Update()

--- a/GameProject/Bar3d/Bar3d.h
+++ b/GameProject/Bar3d/Bar3d.h
@@ -12,7 +12,7 @@ public:
     Bar3d() = default;
     ~Bar3d() = default;
 
-    void Initialize();
+    void Initialize(const Color& colorContext = 0xff0000ff, const Color& colorBG = 0x000000cc);
     void Update();
     void Draw2d();
     void Display(float _sec);


### PR DESCRIPTION
### Bar3d.cpp
- `Initialize`メソッドに`colorContext`と`colorBG`の引数を追加し、背景スプライトの初期化に使用する色を引数で指定できるようにしました。

### Bar3d.h
- `Initialize`メソッドの宣言を更新し、デフォルト引数として`colorContext`に`0xff0000ff`、`colorBG`に`0x000000cc`を設定しました。これにより、引数を指定しない場合でも適切に動作します。

バイナリファイルやJSONの変更はありません。