### PR TITLE
feat: CellBasedFilteringに再割り当て機能を追加

### DIFF
--- a/GameProject/Features/CellBasedFiltering/CellBasedFiltering.h
+++ b/GameProject/Features/CellBasedFiltering/CellBasedFiltering.h
@@ -20,6 +20,7 @@ public:
     void RegisterPotentials(AABBCollider* pCollider);
     void RegisterAll(CollisionManager* pManager);
     void UnregisterAll(CollisionManager* pManager);
+    void ReassignToGridAll(int cellSize);
 
 private:
     uint64_t ToCellIndex(const Vector3& position) const;
@@ -33,4 +34,5 @@ private:
     std::vector<std::vector<AABBCollider*>> grid_;
     std::set<AABBCollider*> potentialColliders_;
     std::set<uint64_t> uniqueCells_;
+    bool isModifyMode_ = false;
 };

--- a/GameProject/Terrain/Block/Block.cpp
+++ b/GameProject/Terrain/Block/Block.cpp
@@ -31,9 +31,8 @@ void Block::Initialize(std::unique_ptr<ModelInstance> modelInstance)
     modelInstance_ = std::move(modelInstance);
     modelInstance_->SetScale(Vector3(kScale, kScale, kScale));
     collider_ = std::make_unique<AABBCollider>();
-    auto tf = modelInstance_->GetTransform();
-    collider_->SetTransform(&tf);
-    collider_->SetOffset(tf.translate);
+    transform_ = modelInstance_->GetTransform();
+    collider_->SetTransform(&transform_);
     collider_->SetSize({kScale, kScale, kScale});
     collider_->SetOwner(this);
     collider_->SetTypeID(static_cast<uint32_t>(CollisionTypeId::kTerrain));

--- a/GameProject/Terrain/Block/Block.h
+++ b/GameProject/Terrain/Block/Block.h
@@ -45,6 +45,7 @@ public:
     AABBCollider* GetCollider() const { return collider_.get(); }
 
 private:
+    Transform transform_{};
     Colors color_ = Colors::White;
     std::unique_ptr<ModelInstance> modelInstance_;
     std::unique_ptr<AABBCollider> collider_;

--- a/GameProject/imgui.ini
+++ b/GameProject/imgui.ini
@@ -63,15 +63,15 @@ DockId=0x0000000C,2
 
 [Window][FollowCamera]
 Pos=0,45
-Size=442,278
+Size=442,272
 Collapsed=0
-DockId=0x00000007,0
+DockId=0x0000000D,0
 
 [Window][Shadow Mapping]
 Pos=0,45
-Size=442,278
+Size=442,272
 Collapsed=0
-DockId=0x00000007,1
+DockId=0x0000000D,1
 
 [Window][Player Debug]
 Pos=-1,71
@@ -89,8 +89,8 @@ Size=171,55
 Collapsed=0
 
 [Window][CollisionManager Debug]
-Pos=0,325
-Size=442,575
+Pos=0,438
+Size=442,462
 Collapsed=0
 DockId=0x00000008,0
 
@@ -113,16 +113,16 @@ Collapsed=0
 DockId=0x0000000B,0
 
 [Window][Player]
-Pos=0,45
-Size=442,278
+Pos=0,319
+Size=442,117
 Collapsed=0
-DockId=0x00000007,3
+DockId=0x0000000E,0
 
 [Window][Terrain]
 Pos=0,45
-Size=442,278
+Size=442,272
 Collapsed=0
-DockId=0x00000007,2
+DockId=0x0000000D,2
 
 [Window][Bar2d (No Name)]
 Pos=0,546
@@ -134,12 +134,30 @@ DockId=0x00000008,1
 Pos=0,45
 Size=442,278
 Collapsed=0
-DockId=0x00000007,4
+DockId=0x0000000D,4
 
 [Window][Cell Based Filtering]
-Pos=453,667
-Size=382,227
+Pos=244,587
+Size=442,205
 Collapsed=0
+
+[Window][Boss Control Panel]
+Pos=0,438
+Size=442,462
+Collapsed=0
+DockId=0x00000008,3
+
+[Window][[Boss.gltf] Info]
+Pos=0,438
+Size=442,462
+Collapsed=0
+DockId=0x00000008,1
+
+[Window][Energy Core Manager]
+Pos=0,438
+Size=442,462
+Collapsed=0
+DockId=0x00000008,2
 
 [Docking][Data]
 DockSpace         ID=0xF852211D Window=0xA87D555D Pos=0,0 Size=1600,900 Split=Y Selected=0x4E65C02E
@@ -148,8 +166,10 @@ DockSpace         ID=0xF852211D Window=0xA87D555D Pos=0,0 Size=1600,900 Split=Y 
     DockNode      ID=0x00000006 Parent=0x00000003 SizeRef=287,60 HiddenTabBar=1 Selected=0x6108FA95
   DockNode        ID=0x00000004 Parent=0xF852211D SizeRef=1280,855 Split=X
     DockNode      ID=0x00000001 Parent=0x00000004 SizeRef=442,720 Split=Y Selected=0xDE934E82
-      DockNode    ID=0x00000007 Parent=0x00000001 SizeRef=318,278 Selected=0xF6D15C51
-      DockNode    ID=0x00000008 Parent=0x00000001 SizeRef=318,575 Selected=0x39D99776
+      DockNode    ID=0x00000007 Parent=0x00000001 SizeRef=318,474 Split=Y Selected=0xB2E5801E
+        DockNode  ID=0x0000000D Parent=0x00000007 SizeRef=442,330 Selected=0xDE934E82
+        DockNode  ID=0x0000000E Parent=0x00000007 SizeRef=442,142 Selected=0xF6D15C51
+      DockNode    ID=0x00000008 Parent=0x00000001 SizeRef=318,559 Selected=0x39D99776
     DockNode      ID=0x00000002 Parent=0x00000004 SizeRef=1156,720 Split=X Selected=0x4E65C02E
       DockNode    ID=0x00000009 Parent=0x00000002 SizeRef=318,675 Selected=0xD52612CC
       DockNode    ID=0x0000000A Parent=0x00000002 SizeRef=960,675 Split=X Selected=0x4E65C02E


### PR DESCRIPTION
- `CellBasedFiltering`クラスに新しいメソッド`ReassignToGridAll`を追加し、全てのコライダーを新しいグリッドに再割り当てする機能を実装。
- `DrawImGui`メソッドを変更し、セルサイズの表示や調整が可能に。新たに"Reassign All"ボタンを追加。
- `AssignToGrid`および`RegisterPotentials`メソッドでAABBの計算を修正し、コライダーの中心を考慮しないように変更。
- `CellBasedFiltering.h`に`ReassignToGridAll`メソッドの宣言と`isModifyMode_`メンバー変数を追加。
- `Block`クラスの`Initialize`メソッドでコライダーの変換設定をモデルインスタンスの変換を直接使用するように変更。

- `imgui.ini`ファイルにおいて、ウィンドウの位置やサイズに関する調整を実施。