### PR TITLE
change: Terrain::GetMaxYAtの実装を修正

### DIFF
--- a/GameProject/Terrain/Terrain.cpp
+++ b/GameProject/Terrain/Terrain.cpp
@@ -200,7 +200,9 @@ float Terrain::GetMaxYAt(float x, float z)
     {
         if (blocks_[ix][y][iz])
         {
-            return -static_cast<float>(y) * Block::kScale;
+            // ブロックの上面の高さを返す
+            auto posBlock = blocks_[ix][y][iz]->GetPosition();
+            return posBlock.y + (Block::kScale / 2.0f);
         }
     }
 


### PR DESCRIPTION
* `Terrain::GetMaxYAt` 関数の実装を変更し、ブロックが見つかった場合にブロックの上面の高さを正確に計算して返すようにしました。
* 以前の実装では、ブロックのインデックスに基づいて単純な計算を行っていましたが、現在は `blocks_[ix][y][iz]->GetPosition()` を使用してブロックの位置を取得し、その高さに `Block::kScale / 2.0f` を加算して返します。

バイナリファイルやJSONファイルに関する変更はありません。